### PR TITLE
Version 1.1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 ## FAQ
 Q: What versions does this plugin support?
 
-A: 1.21.4, 1.21.5, 1.21.6, 1.21.7, 1.21.8 and 1.21.9.
+A: 1.21.4, 1.21.5, 1.21.6, 1.21.7, 1.21.8, 1.21.9, and 1.21.10.
 
 Q: Are there any plans to support any other versions?
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.21.9-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.10-R0.1-SNAPSHOT")
     compileOnly("com.github.lukesky19:SkyLib:1.3.1.0")
     compileOnly("com.github.MilkBowl:VaultAPI:1.7.1")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.github.lukesky19"
-version = "1.1.1.0"
+version = "1.1.1.1"
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/github/lukesky19/skyHoppers/gui/SkyHopperGUI.java
+++ b/src/main/java/com/github/lukesky19/skyHoppers/gui/SkyHopperGUI.java
@@ -82,6 +82,10 @@ public abstract class SkyHopperGUI implements ButtonGUI {
      * Is the GUI currently open?
      */
     protected boolean isOpen = false;
+    /**
+     * The {@link SkyHopperGUI} previously opened.
+     */
+    protected final @Nullable SkyHopperGUI previousGUI;
 
     /**
      * Constructor.
@@ -89,14 +93,21 @@ public abstract class SkyHopperGUI implements ButtonGUI {
      * @param guiManager The {@link GUIManager} that is used to track open GUIs.
      * @param player The {@link Player} associated with the created GUI.
      * @param location The {@link Location} of the SkyHopper the GUI is for.
+     * @param previousGUI The previous {@link SkyHopperGUI} opened before opening this one.
      */
-    public SkyHopperGUI(@NotNull SkyHoppers skyHoppers, @NotNull GUIManager guiManager, @NotNull Player player, @NotNull Location location) {
+    public SkyHopperGUI(
+            @NotNull SkyHoppers skyHoppers,
+            @NotNull GUIManager guiManager,
+            @NotNull Player player,
+            @NotNull Location location,
+            @Nullable SkyHopperGUI previousGUI) {
         this.skyHoppers = skyHoppers;
         this.logger = skyHoppers.getComponentLogger();
         this.guiManager = guiManager;
         this.player = player;
         this.uuid = player.getUniqueId();
         this.location = location;
+        this.previousGUI = previousGUI;
     }
 
     /**
@@ -151,37 +162,40 @@ public abstract class SkyHopperGUI implements ButtonGUI {
             return false;
         }
 
-        // Close the current Inventory the player has open (if any)
-        skyHoppers.getServer().getScheduler().runTaskLater(skyHoppers, () -> {
-            player.closeInventory(InventoryCloseEvent.Reason.OPEN_NEW);
-
-            guiManager.removeViewer(location, uuid);
-        }, 1L);
-
-        // Then 1 tick later, open the GUI and track that it is open for the player.
+        // 1 tick later, open the GUI and track that it is open for the player.
         skyHoppers.getServer().getScheduler().runTaskLater(skyHoppers, () -> {
             inventoryView.open();
 
             guiManager.addViewer(location, uuid, this);
-        }, 2L);
 
-        isOpen = true;
+            this.isOpen = true;
+        }, 1L);
 
         return true;
     }
 
     /**
-     * Close the GUI with an UNLOADED {@link InventoryCloseEvent.Reason}.
+     * If the previous GUI is not null, close the GUI with {@link InventoryCloseEvent.Reason#OPEN_NEW}.
+     * Otherwise, close the GUI with {@link InventoryCloseEvent.Reason#UNLOADED}.
      * You should use {@link #unload(boolean)} if the plugin is being disabled, and you are trying to close open GUIs.
      */
     @Override
     public void close() {
-        skyHoppers.getServer().getScheduler().runTaskLater(skyHoppers, () ->
-                player.closeInventory(InventoryCloseEvent.Reason.UNLOADED), 1L);
+        skyHoppers.getServer().getScheduler().runTaskLater(skyHoppers, () -> {
+            guiManager.removeViewer(location, uuid);
 
-        guiManager.removeViewer(location, uuid);
+            this.isOpen = false;
 
-        this.isOpen = false;
+            if(previousGUI != null) {
+                player.closeInventory(InventoryCloseEvent.Reason.OPEN_NEW);
+
+                previousGUI.update();
+
+                previousGUI.open();
+            } else {
+                player.closeInventory(InventoryCloseEvent.Reason.UNLOADED);
+            }
+        }, 1L);
     }
 
     /**

--- a/src/main/java/com/github/lukesky19/skyHoppers/gui/menu/HopperGUI.java
+++ b/src/main/java/com/github/lukesky19/skyHoppers/gui/menu/HopperGUI.java
@@ -94,7 +94,8 @@ public class HopperGUI extends SkyHopperGUI {
             @NotNull GUIConfigManager guiConfigManager,
             @NotNull HopperManager hopperManager,
             @NotNull HopperClickListener hopperClickListener) {
-        super(skyHoppers, guiManager, player, location);
+        super(skyHoppers, guiManager, player, location, null);
+
         this.settingsManager = settingsManager;
         this.localeManager = localeManager;
         this.guiConfigManager = guiConfigManager;
@@ -677,12 +678,8 @@ public class HopperGUI extends SkyHopperGUI {
 
             builder.setItemStack(optionalItemStack.get());
 
-            builder.setAction(event -> {
-                skyHoppers.getServer().getScheduler().runTaskLater(skyHoppers, () ->
-                        player.closeInventory(InventoryCloseEvent.Reason.UNLOADED), 1L);
-
-                guiManager.removeViewer(location, player.getUniqueId());
-            });
+            builder.setAction(event ->
+                    skyHoppers.getServer().getScheduler().runTaskLater(skyHoppers, this::close, 1L));
 
             setButton(buttonConfig.slot(), builder.build());
         }

--- a/src/main/java/com/github/lukesky19/skyHoppers/gui/menu/filter/InputFilterGUI.java
+++ b/src/main/java/com/github/lukesky19/skyHoppers/gui/menu/filter/InputFilterGUI.java
@@ -60,8 +60,6 @@ import java.util.Optional;
 public class InputFilterGUI extends SkyHopperGUI {
     private final @NotNull HopperManager hopperManager;
 
-    private final @NotNull HopperGUI hopperGUI;
-
     private final @NotNull SkyHopper skyHopper;
 
     private final @Nullable GUIConfig guiConfig;
@@ -89,10 +87,9 @@ public class InputFilterGUI extends SkyHopperGUI {
             @NotNull GUIConfigManager guiConfigManager,
             @NotNull HopperManager hopperManager,
             @NotNull HopperGUI hopperGUI) {
-        super(skyHoppers, guiManager, player, location);
+        super(skyHoppers, guiManager, player, location, hopperGUI);
 
         this.hopperManager = hopperManager;
-        this.hopperGUI = hopperGUI;
 
         this.skyHopper = skyHopper;
 
@@ -169,18 +166,6 @@ public class InputFilterGUI extends SkyHopperGUI {
     }
 
     /**
-     * Close the current GUI and open the {@link HopperGUI} that the player came from.
-     */
-    @Override
-    public void close() {
-        super.close();
-
-        hopperGUI.update();
-
-        hopperGUI.open();
-    }
-
-    /**
      * Handles when the player closes the GUI.
      * @param inventoryCloseEvent An InventoryCloseEvent
      */
@@ -192,9 +177,11 @@ public class InputFilterGUI extends SkyHopperGUI {
 
         isOpen = false;
 
-        hopperGUI.update();
+        if(previousGUI != null) {
+            previousGUI.update();
 
-        hopperGUI.open();
+            previousGUI.open();
+        }
     }
 
     /**

--- a/src/main/java/com/github/lukesky19/skyHoppers/gui/menu/filter/InputFilterGUI.java
+++ b/src/main/java/com/github/lukesky19/skyHoppers/gui/menu/filter/InputFilterGUI.java
@@ -208,25 +208,32 @@ public class InputFilterGUI extends SkyHopperGUI {
     public void handleBottomClick(@NotNull InventoryClickEvent inventoryClickEvent) {
         inventoryClickEvent.setCancelled(true);
 
-        ItemStack item = inventoryClickEvent.getCurrentItem();
-        if(item != null && item.getType() != Material.AIR) {
-            ItemType itemType = item.getType().asItemType();
-            if(itemType == null) {
-                logger.warn(AdventureUtil.serialize("Unable to add an item to the filter as there is no ItemType for Material " + FormatUtil.formatMaterialName(item.getType())));
-                return;
-            }
+        // Get the clicked ItemStack
+        ItemStack clickedItemStack = inventoryClickEvent.getCurrentItem();
+        if(clickedItemStack == null) return;
 
-            skyHopper.addFilterItem(itemType);
+        // Check if the Material is AIR
+        Material material = clickedItemStack.getType();
+        if(material.equals(Material.AIR)) return;
 
-            hopperManager.saveSkyHopperToPDC(skyHopper);
-
-            guiManager.refreshViewersGUI(location);
-
-            added = 0;
-            itemNum = 0;
-
-            update();
+        // Get the ItemType
+        ItemType itemType = material.asItemType();
+        if(itemType == null) {
+            logger.warn(AdventureUtil.serialize("Unable to add an item to the filter as there is no ItemType for Material " + FormatUtil.formatMaterialName(material)));
+            return;
         }
+
+        // Add the ItemType to the filter
+        skyHopper.addFilterItem(itemType);
+
+        hopperManager.saveSkyHopperToPDC(skyHopper);
+
+        guiManager.refreshViewersGUI(location);
+
+        added = 0;
+        itemNum = 0;
+
+        update();
     }
 
     /**

--- a/src/main/java/com/github/lukesky19/skyHoppers/gui/menu/filter/OutputFilterGUI.java
+++ b/src/main/java/com/github/lukesky19/skyHoppers/gui/menu/filter/OutputFilterGUI.java
@@ -226,9 +226,6 @@ public class OutputFilterGUI extends SkyHopperGUI {
             return;
         }
 
-        // Check if the item is already filtered
-        if(!skyContainer.getFilterItems().contains(itemType)) return;
-
         // Add the ItemType to the filter
         skyContainer.addFilterItem(itemType);
 

--- a/src/main/java/com/github/lukesky19/skyHoppers/gui/menu/filter/OutputFilterGUI.java
+++ b/src/main/java/com/github/lukesky19/skyHoppers/gui/menu/filter/OutputFilterGUI.java
@@ -52,14 +52,12 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 /**
  * This class lets Players manage the output filter items and filter type.
  */
 public class OutputFilterGUI extends SkyHopperGUI {
     private final @NotNull HopperManager hopperManager;
-    private final @NotNull LinksGUI linksGUI;
 
     private final @NotNull SkyHopper skyHopper;
     private final @NotNull SkyContainer skyContainer;
@@ -91,10 +89,9 @@ public class OutputFilterGUI extends SkyHopperGUI {
             @NotNull HopperManager hopperManager,
             @NotNull SkyContainer skyContainer,
             @NotNull LinksGUI linksGUI) {
-        super(skyHoppers, guiManager, player, location);
+        super(skyHoppers, guiManager, player, location, linksGUI);
 
         this.hopperManager = hopperManager;
-        this.linksGUI = linksGUI;
 
         this.skyHopper = skyHopper;
         this.skyContainer = skyContainer;
@@ -172,18 +169,6 @@ public class OutputFilterGUI extends SkyHopperGUI {
     }
 
     /**
-     * Close the current GUI and open the {@link LinksGUI} that the player came from.
-     */
-    @Override
-    public void close() {
-        super.close();
-
-        linksGUI.update();
-
-        linksGUI.open();
-    }
-
-    /**
      * Handles when the player closes the GUI.
      * @param inventoryCloseEvent An InventoryCloseEvent
      */
@@ -191,16 +176,15 @@ public class OutputFilterGUI extends SkyHopperGUI {
     public void handleClose(@NotNull InventoryCloseEvent inventoryCloseEvent) {
         if(inventoryCloseEvent.getReason().equals(InventoryCloseEvent.Reason.UNLOADED) || inventoryCloseEvent.getReason().equals(InventoryCloseEvent.Reason.OPEN_NEW)) return;
 
-        Player player = (Player) inventoryCloseEvent.getPlayer();
-        UUID uuid = player.getUniqueId();
-
         guiManager.removeViewer(location, uuid);
 
         this.isOpen = false;
 
-        linksGUI.update();
+        if(previousGUI != null) {
+            previousGUI.update();
 
-        linksGUI.open();
+            previousGUI.open();
+        }
     }
 
     /**

--- a/src/main/java/com/github/lukesky19/skyHoppers/gui/menu/links/LinksGUI.java
+++ b/src/main/java/com/github/lukesky19/skyHoppers/gui/menu/links/LinksGUI.java
@@ -66,8 +66,6 @@ public class LinksGUI extends SkyHopperGUI {
     private final @NotNull HopperManager hopperManager;
     private final @NotNull HopperClickListener hopperClickListener;
 
-    private final @NotNull HopperGUI hopperGUI;
-
     private final @NotNull SkyHopper skyHopper;
 
     private final @Nullable GUIConfig guiConfig;
@@ -99,14 +97,12 @@ public class LinksGUI extends SkyHopperGUI {
             @NotNull HopperManager hopperManager,
             @NotNull HopperClickListener hopperClickListener,
             @NotNull HopperGUI hopperGUI) {
-        super(skyHoppers, guiManager, player, location);
+        super(skyHoppers, guiManager, player, location, hopperGUI);
 
         this.localeManager = localeManager;
         this.guiConfigManager = guiConfigManager;
         this.hopperManager = hopperManager;
         this.hopperClickListener = hopperClickListener;
-
-        this.hopperGUI = hopperGUI;
 
         this.skyHopper = skyHopper;
 
@@ -183,18 +179,6 @@ public class LinksGUI extends SkyHopperGUI {
     }
 
     /**
-     * Closes the current GUI and opens the {@link HopperGUI} the player came from.
-     */
-    @Override
-    public void close() {
-        super.close();
-
-        hopperGUI.update();
-
-        hopperGUI.open();
-    }
-
-    /**
      * Handles when the player closes the GUI.
      * @param inventoryCloseEvent An InventoryCloseEvent
      */
@@ -206,9 +190,11 @@ public class LinksGUI extends SkyHopperGUI {
 
         isOpen = false;
 
-        hopperGUI.update();
+        if(previousGUI != null) {
+            previousGUI.update();
 
-        hopperGUI.open();
+            previousGUI.open();
+        }
     }
 
     /**

--- a/src/main/java/com/github/lukesky19/skyHoppers/gui/menu/member/MembersGUI.java
+++ b/src/main/java/com/github/lukesky19/skyHoppers/gui/menu/member/MembersGUI.java
@@ -65,8 +65,6 @@ public class MembersGUI extends SkyHopperGUI {
 
     private final @NotNull SkyHopper skyHopper;
 
-    private final @NotNull HopperGUI hopperGUI;
-
     private final @Nullable GUIConfig guiConfig;
 
     private int playerNum = 0;
@@ -94,15 +92,13 @@ public class MembersGUI extends SkyHopperGUI {
             @NotNull GUIConfigManager guiConfigManager,
             @NotNull HopperManager hopperManager,
             @NotNull HopperGUI hopperGUI) {
-        super(skyHoppers, guiManager, player, location);
+        super(skyHoppers, guiManager, player, location, hopperGUI);
 
         this.localeManager = localeManager;
         this.guiConfigManager = guiConfigManager;
         this.hopperManager = hopperManager;
 
         this.skyHopper = skyHopper;
-
-        this.hopperGUI = hopperGUI;
 
         guiConfig = guiConfigManager.getGuiConfig("members.yml");
     }
@@ -178,18 +174,6 @@ public class MembersGUI extends SkyHopperGUI {
     }
 
     /**
-     * Close the current GUI and open the {@link HopperGUI} that the player came from.
-     */
-    @Override
-    public void close() {
-        super.close();
-
-        hopperGUI.update();
-
-        hopperGUI.open();
-    }
-
-    /**
      * Handles when the player closes the GUI.
      * @param inventoryCloseEvent An InventoryCloseEvent
      */
@@ -201,9 +185,11 @@ public class MembersGUI extends SkyHopperGUI {
 
         isOpen = false;
 
-        hopperGUI.update();
+        if(previousGUI != null) {
+            previousGUI.update();
 
-        hopperGUI.open();
+            previousGUI.open();
+        }
     }
 
     /**

--- a/src/main/java/com/github/lukesky19/skyHoppers/gui/menu/member/SelectPlayerGUI.java
+++ b/src/main/java/com/github/lukesky19/skyHoppers/gui/menu/member/SelectPlayerGUI.java
@@ -61,8 +61,6 @@ public class SelectPlayerGUI extends SkyHopperGUI {
 
     private final @NotNull SkyHopper skyHopper;
 
-    private final @NotNull MembersGUI membersGUI;
-
     private final @Nullable GUIConfig guiConfig;
 
     private int playerNum = 0;
@@ -88,13 +86,11 @@ public class SelectPlayerGUI extends SkyHopperGUI {
             @NotNull GUIConfigManager guiConfigManager,
             @NotNull HopperManager hopperManager,
             @NotNull MembersGUI membersGUI) {
-        super(skyHoppers, guiManager, player, location);
+        super(skyHoppers, guiManager, player, location, membersGUI);
 
         this.hopperManager = hopperManager;
 
         this.skyHopper = skyHopper;
-
-        this.membersGUI = membersGUI;
 
         guiConfig = guiConfigManager.getGuiConfig("select_player.yml");
     }
@@ -169,18 +165,6 @@ public class SelectPlayerGUI extends SkyHopperGUI {
     }
 
     /**
-     * Close the current GUI and open the {@link MembersGUI} that the player came from.
-     */
-    @Override
-    public void close() {
-        super.close();
-
-        membersGUI.update();
-
-        membersGUI.open();
-    }
-
-    /**
      * Handles when the player closes the GUI.
      * @param inventoryCloseEvent An InventoryCloseEvent
      */
@@ -192,9 +176,11 @@ public class SelectPlayerGUI extends SkyHopperGUI {
 
         isOpen = false;
 
-        membersGUI.update();
+        if(previousGUI != null) {
+            previousGUI.update();
 
-        membersGUI.open();
+            previousGUI.open();
+        }
     }
 
     /**

--- a/src/main/java/com/github/lukesky19/skyHoppers/gui/menu/upgrades/LinksUpgradeGUI.java
+++ b/src/main/java/com/github/lukesky19/skyHoppers/gui/menu/upgrades/LinksUpgradeGUI.java
@@ -56,8 +56,6 @@ public class LinksUpgradeGUI extends SkyHopperGUI {
     private final @NotNull LocaleManager localeManager;
     private final @NotNull HopperManager hopperManager;
 
-    private final @NotNull UpgradesGUI upgradesGUI;
-
     private final @NotNull SkyHopper skyHopper;
 
     private final @Nullable UpgradeGUIConfig guiConfig;
@@ -86,15 +84,13 @@ public class LinksUpgradeGUI extends SkyHopperGUI {
             @NotNull GUIConfigManager guiConfigManager,
             @NotNull HopperManager hopperManager,
             @NotNull UpgradesGUI upgradesGUI) {
-        super(skyHoppers, guiManager, player, location);
+        super(skyHoppers, guiManager, player, location, upgradesGUI);
 
         this.settingsManager = settingsManager;
         this.localeManager = localeManager;
         this.hopperManager = hopperManager;
 
         this.skyHopper = skyHopper;
-
-        this.upgradesGUI = upgradesGUI;
 
         guiConfig = guiConfigManager.getUpgradeConfig("links.yml");
     }
@@ -169,18 +165,6 @@ public class LinksUpgradeGUI extends SkyHopperGUI {
     }
 
     /**
-     * Close the current GUI and open the {@link UpgradesGUI} that the player came from.
-     */
-    @Override
-    public void close() {
-        super.close();
-
-        upgradesGUI.update();
-
-        upgradesGUI.open();
-    }
-
-    /**
      * Handles when the player closes the GUI.
      * @param inventoryCloseEvent An InventoryCloseEvent
      */
@@ -192,9 +176,11 @@ public class LinksUpgradeGUI extends SkyHopperGUI {
 
         isOpen = false;
 
-        upgradesGUI.update();
+        if(previousGUI != null) {
+            previousGUI.update();
 
-        upgradesGUI.open();
+            previousGUI.open();
+        }
     }
 
     /**

--- a/src/main/java/com/github/lukesky19/skyHoppers/gui/menu/upgrades/SuctionAmountUpgradeGUI.java
+++ b/src/main/java/com/github/lukesky19/skyHoppers/gui/menu/upgrades/SuctionAmountUpgradeGUI.java
@@ -56,8 +56,6 @@ public class SuctionAmountUpgradeGUI extends SkyHopperGUI {
     private final @NotNull LocaleManager localeManager;
     private final @NotNull HopperManager hopperManager;
 
-    private final @NotNull UpgradesGUI upgradesGUI;
-
     private final @NotNull SkyHopper skyHopper;
 
     private final @Nullable UpgradeGUIConfig guiConfig;
@@ -86,15 +84,13 @@ public class SuctionAmountUpgradeGUI extends SkyHopperGUI {
             @NotNull GUIConfigManager guiConfigManager,
             @NotNull HopperManager hopperManager,
             @NotNull UpgradesGUI upgradesGUI) {
-        super(skyHoppers, guiManager, player, location);
+        super(skyHoppers, guiManager, player, location, upgradesGUI);
 
         this.settingsManager = settingsManager;
         this.localeManager = localeManager;
         this.hopperManager = hopperManager;
 
         this.skyHopper = skyHopper;
-
-        this.upgradesGUI = upgradesGUI;
 
         guiConfig = guiConfigManager.getUpgradeConfig("suction_amount.yml");
     }
@@ -171,18 +167,6 @@ public class SuctionAmountUpgradeGUI extends SkyHopperGUI {
     }
 
     /**
-     * Close the current GUI and open the {@link UpgradesGUI} that the player came from.
-     */
-    @Override
-    public void close() {
-        super.close();
-
-        upgradesGUI.update();
-
-        upgradesGUI.open();
-    }
-
-    /**
      * Handles when the player closes the GUI.
      * @param inventoryCloseEvent An InventoryCloseEvent
      */
@@ -194,9 +178,11 @@ public class SuctionAmountUpgradeGUI extends SkyHopperGUI {
 
         isOpen = false;
 
-        upgradesGUI.update();
+        if(previousGUI != null) {
+            previousGUI.update();
 
-        upgradesGUI.open();
+            previousGUI.open();
+        }
     }
 
     /**

--- a/src/main/java/com/github/lukesky19/skyHoppers/gui/menu/upgrades/SuctionRangeUpgradeGUI.java
+++ b/src/main/java/com/github/lukesky19/skyHoppers/gui/menu/upgrades/SuctionRangeUpgradeGUI.java
@@ -56,8 +56,6 @@ public class SuctionRangeUpgradeGUI extends SkyHopperGUI {
     private final @NotNull LocaleManager localeManager;
     private final @NotNull HopperManager hopperManager;
 
-    private final @NotNull UpgradesGUI upgradesGUI;
-
     private final @NotNull SkyHopper skyHopper;
 
     private final @Nullable UpgradeGUIConfig guiConfig;
@@ -86,15 +84,13 @@ public class SuctionRangeUpgradeGUI extends SkyHopperGUI {
             @NotNull GUIConfigManager guiConfigManager,
             @NotNull HopperManager hopperManager,
             @NotNull UpgradesGUI upgradesGUI) {
-        super(skyHoppers, guiManager, player, location);
+        super(skyHoppers, guiManager, player, location, upgradesGUI);
 
         this.settingsManager = settingsManager;
         this.localeManager = localeManager;
         this.hopperManager = hopperManager;
 
         this.skyHopper = skyHopper;
-
-        this.upgradesGUI = upgradesGUI;
 
         guiConfig = guiConfigManager.getUpgradeConfig("suction_range.yml");
     }
@@ -171,18 +167,6 @@ public class SuctionRangeUpgradeGUI extends SkyHopperGUI {
     }
 
     /**
-     * Close the current GUI and open the {@link UpgradesGUI} that the player came from.
-     */
-    @Override
-    public void close() {
-        super.close();
-
-        upgradesGUI.update();
-
-        upgradesGUI.open();
-    }
-
-    /**
      * Handles when the player closes the GUI.
      * @param inventoryCloseEvent An InventoryCloseEvent
      */
@@ -194,9 +178,11 @@ public class SuctionRangeUpgradeGUI extends SkyHopperGUI {
 
         isOpen = false;
 
-        upgradesGUI.update();
+        if(previousGUI != null) {
+            previousGUI.update();
 
-        upgradesGUI.open();
+            previousGUI.open();
+        }
     }
 
     /**

--- a/src/main/java/com/github/lukesky19/skyHoppers/gui/menu/upgrades/SuctionSpeedUpgradeGUI.java
+++ b/src/main/java/com/github/lukesky19/skyHoppers/gui/menu/upgrades/SuctionSpeedUpgradeGUI.java
@@ -56,8 +56,6 @@ public class SuctionSpeedUpgradeGUI extends SkyHopperGUI {
     private final @NotNull LocaleManager localeManager;
     private final @NotNull HopperManager hopperManager;
 
-    private final @NotNull UpgradesGUI upgradesGUI;
-
     private final @NotNull SkyHopper skyHopper;
 
     private final @Nullable UpgradeGUIConfig guiConfig;
@@ -86,15 +84,13 @@ public class SuctionSpeedUpgradeGUI extends SkyHopperGUI {
             @NotNull GUIConfigManager guiConfigManager,
             @NotNull HopperManager hopperManager,
             @NotNull UpgradesGUI upgradesGUI) {
-        super(skyHoppers, guiManager, player, location);
+        super(skyHoppers, guiManager, player, location, upgradesGUI);
 
         this.settingsManager = settingsManager;
         this.localeManager = localeManager;
         this.hopperManager = hopperManager;
 
         this.skyHopper = skyHopper;
-
-        this.upgradesGUI = upgradesGUI;
 
         guiConfig = guiConfigManager.getUpgradeConfig("suction_speed.yml");
     }
@@ -171,18 +167,6 @@ public class SuctionSpeedUpgradeGUI extends SkyHopperGUI {
     }
 
     /**
-     * Close the current GUI and open the {@link UpgradesGUI} that the player came from.
-     */
-    @Override
-    public void close() {
-        super.close();
-
-        upgradesGUI.update();
-
-        upgradesGUI.open();
-    }
-
-    /**
      * Handles when the player closes the GUI.
      * @param inventoryCloseEvent An InventoryCloseEvent
      */
@@ -194,9 +178,11 @@ public class SuctionSpeedUpgradeGUI extends SkyHopperGUI {
 
         isOpen = false;
 
-        upgradesGUI.update();
+        if(previousGUI != null) {
+            previousGUI.update();
 
-        upgradesGUI.open();
+            previousGUI.open();
+        }
     }
 
     /**

--- a/src/main/java/com/github/lukesky19/skyHoppers/gui/menu/upgrades/TransferAmountUpgradeGUI.java
+++ b/src/main/java/com/github/lukesky19/skyHoppers/gui/menu/upgrades/TransferAmountUpgradeGUI.java
@@ -56,8 +56,6 @@ public class TransferAmountUpgradeGUI extends SkyHopperGUI {
     private final @NotNull LocaleManager localeManager;
     private final @NotNull HopperManager hopperManager;
 
-    private final @NotNull UpgradesGUI upgradesGUI;
-
     private final @NotNull SkyHopper skyHopper;
 
     private final @Nullable UpgradeGUIConfig guiConfig;
@@ -86,15 +84,13 @@ public class TransferAmountUpgradeGUI extends SkyHopperGUI {
             @NotNull GUIConfigManager guiConfigManager,
             @NotNull HopperManager hopperManager,
             @NotNull UpgradesGUI upgradesGUI) {
-        super(skyHoppers, guiManager, player, location);
+        super(skyHoppers, guiManager, player, location, upgradesGUI);
 
         this.settingsManager = settingsManager;
         this.localeManager = localeManager;
         this.hopperManager = hopperManager;
 
         this.skyHopper = skyHopper;
-
-        this.upgradesGUI = upgradesGUI;
 
         guiConfig = guiConfigManager.getUpgradeConfig("transfer_amount.yml");
     }
@@ -171,18 +167,6 @@ public class TransferAmountUpgradeGUI extends SkyHopperGUI {
     }
 
     /**
-     * Close the current GUI and open the {@link UpgradesGUI} that the player came from.
-     */
-    @Override
-    public void close() {
-        super.close();
-
-        upgradesGUI.update();
-
-        upgradesGUI.open();
-    }
-
-    /**
      * Handles when the player closes the GUI.
      * @param inventoryCloseEvent An InventoryCloseEvent
      */
@@ -194,9 +178,11 @@ public class TransferAmountUpgradeGUI extends SkyHopperGUI {
 
         isOpen = false;
 
-        upgradesGUI.update();
+        if(previousGUI != null) {
+            previousGUI.update();
 
-        upgradesGUI.open();
+            previousGUI.open();
+        }
     }
 
     /**

--- a/src/main/java/com/github/lukesky19/skyHoppers/gui/menu/upgrades/TransferSpeedUpgradeGUI.java
+++ b/src/main/java/com/github/lukesky19/skyHoppers/gui/menu/upgrades/TransferSpeedUpgradeGUI.java
@@ -56,8 +56,6 @@ public class TransferSpeedUpgradeGUI extends SkyHopperGUI {
     private final @NotNull LocaleManager localeManager;
     private final @NotNull HopperManager hopperManager;
 
-    private final @NotNull UpgradesGUI upgradesGUI;
-
     private final @NotNull SkyHopper skyHopper;
 
     private final @Nullable UpgradeGUIConfig guiConfig;
@@ -86,15 +84,13 @@ public class TransferSpeedUpgradeGUI extends SkyHopperGUI {
             @NotNull GUIConfigManager guiConfigManager,
             @NotNull HopperManager hopperManager,
             @NotNull UpgradesGUI upgradesGUI) {
-        super(skyHoppers, guiManager, player, location);
+        super(skyHoppers, guiManager, player, location, upgradesGUI);
 
         this.settingsManager = settingsManager;
         this.localeManager = localeManager;
         this.hopperManager = hopperManager;
 
         this.skyHopper = skyHopper;
-
-        this.upgradesGUI = upgradesGUI;
 
         guiConfig = guiConfigManager.getUpgradeConfig("transfer_speed.yml");
     }
@@ -171,18 +167,6 @@ public class TransferSpeedUpgradeGUI extends SkyHopperGUI {
     }
 
     /**
-     * Close the current GUI and open the {@link UpgradesGUI} that the player came from.
-     */
-    @Override
-    public void close() {
-        super.close();
-
-        upgradesGUI.update();
-
-        upgradesGUI.open();
-    }
-
-    /**
      * Handles when the player closes the GUI.
      * @param inventoryCloseEvent An InventoryCloseEvent
      */
@@ -194,9 +178,11 @@ public class TransferSpeedUpgradeGUI extends SkyHopperGUI {
 
         isOpen = false;
 
-        upgradesGUI.update();
+        if(previousGUI != null) {
+            previousGUI.update();
 
-        upgradesGUI.open();
+            previousGUI.open();
+        }
     }
 
     /**

--- a/src/main/java/com/github/lukesky19/skyHoppers/gui/menu/upgrades/UpgradesGUI.java
+++ b/src/main/java/com/github/lukesky19/skyHoppers/gui/menu/upgrades/UpgradesGUI.java
@@ -56,8 +56,6 @@ public class UpgradesGUI extends SkyHopperGUI {
     private final @NotNull GUIConfigManager guiConfigManager;
     private final @NotNull HopperManager hopperManager;
 
-    private final @NotNull HopperGUI hopperGUI;
-
     private final @NotNull SkyHopper skyHopper;
 
     private final @Nullable GUIConfig guiConfig;
@@ -86,14 +84,12 @@ public class UpgradesGUI extends SkyHopperGUI {
             @NotNull GUIConfigManager guiConfigManager,
             @NotNull HopperManager hopperManager,
             @NotNull HopperGUI hopperGUI) {
-        super(skyHoppers, guiManager, player, location);
+        super(skyHoppers, guiManager, player, location, hopperGUI);
 
         this.settingsManager = settingsManager;
         this.localeManager = localeManager;
         this.guiConfigManager = guiConfigManager;
         this.hopperManager = hopperManager;
-
-        this.hopperGUI = hopperGUI;
 
         this.skyHopper = skyHopper;
 
@@ -180,18 +176,6 @@ public class UpgradesGUI extends SkyHopperGUI {
     }
 
     /**
-     * Close the current GUI and open the {@link HopperGUI} that the player came from.
-     */
-    @Override
-    public void close() {
-        super.close();
-
-        hopperGUI.update();
-
-        hopperGUI.open();
-    }
-
-    /**
      * Handles when the player closes the GUI.
      * @param inventoryCloseEvent An InventoryCloseEvent
      */
@@ -203,9 +187,11 @@ public class UpgradesGUI extends SkyHopperGUI {
 
         isOpen = false;
 
-        hopperGUI.update();
+        if(previousGUI != null) {
+            previousGUI.update();
 
-        hopperGUI.open();
+            previousGUI.open();
+        }
     }
 
     /**

--- a/src/main/java/com/github/lukesky19/skyHoppers/manager/HopperManager.java
+++ b/src/main/java/com/github/lukesky19/skyHoppers/manager/HopperManager.java
@@ -26,7 +26,9 @@ import com.github.lukesky19.skyHoppers.util.PluginUtils;
 import com.github.lukesky19.skylib.api.adventure.AdventureUtil;
 import com.github.lukesky19.skylib.api.itemstack.ItemStackBuilder;
 import com.github.lukesky19.skylib.api.itemstack.ItemStackConfig;
+import com.github.lukesky19.skylib.api.registry.RegistryUtil;
 import com.github.lukesky19.skylib.libs.morepersistentdatatypes.DataType;
+import net.kyori.adventure.text.logger.slf4j.ComponentLogger;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import org.bukkit.Chunk;
@@ -45,7 +47,6 @@ import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * This class manages {@link SkyHopper}s including storage, creation, and saving.
@@ -338,6 +339,7 @@ public class HopperManager {
      */
     public @Nullable SkyHopper getSkyHopperFromPDC(@Nullable Location location, @NotNull PersistentDataContainer pdc) {
         Locale locale = localeManager.getLocale();
+        ComponentLogger logger = skyHoppers.getComponentLogger();
 
         // Get the skyHoppers's settings
         @Nullable Settings settings = settingsManager.getSettings();
@@ -389,10 +391,14 @@ public class HopperManager {
         // Get the input filter items
         // First handle the modern storage of the filter items.
         if(pdc.has(HopperKeys.FILTER_ITEMS.getKey(), PersistentDataType.LIST.listTypeFrom(PersistentDataType.STRING))) {
-            List<String> modernMaterialNames = pdc.get(HopperKeys.FILTER_ITEMS.getKey(),
+            List<String> modernItemTypeNames = pdc.get(HopperKeys.FILTER_ITEMS.getKey(),
                     PersistentDataType.LIST.listTypeFrom(PersistentDataType.STRING));
-            if(modernMaterialNames != null) {
-                modernMaterialNames.stream().map(Material::getMaterial).filter(Objects::nonNull).map(Material::asItemType).filter(Objects::nonNull).forEach(filterItems::add);
+            if(modernItemTypeNames != null) {
+                modernItemTypeNames.stream()
+                        .map(itemTypeName -> RegistryUtil.getItemType(logger, itemTypeName))
+                        .filter(Optional::isPresent)
+                        .map(Optional::get)
+                        .forEach(filterItems::add);
             }
         }
 
@@ -568,11 +574,11 @@ public class HopperManager {
         // Save the input filter type
         pdc.set(HopperKeys.FILTER_TYPE.getKey(), PersistentDataType.STRING, skyHopper.getFilterType().name());
 
+        // Get a list of the input filter ItemType's NamespacedKeys as a String to save.
+        List<String> inputFilterItemNames = skyHopper.getFilterItems().stream().map(itemType -> itemType.getKey().toString()).toList();
         // Save the input filter items
         pdc.set(HopperKeys.FILTER_ITEMS.getKey(),
-                PersistentDataType.LIST.listTypeFrom(PersistentDataType.STRING),
-                skyHopper.getFilterItems().stream().map(ItemType::toString).filter(Objects::nonNull)
-                        .collect(Collectors.toList()));
+                PersistentDataType.LIST.listTypeFrom(PersistentDataType.STRING), inputFilterItemNames);
 
         // Save the linked containers
         List<PersistentDataContainer> pdcList = new ArrayList<>();
@@ -584,10 +590,12 @@ public class HopperManager {
             PersistentDataContainer persistentDataContainer = pdc.getAdapterContext().newPersistentDataContainer();
             persistentDataContainer.set(HopperKeys.LOCATION.getKey(), DataType.LOCATION, linkedLocation);
             persistentDataContainer.set(HopperKeys.FILTER_TYPE.getKey(), PersistentDataType.STRING, filterType.name());
+
+            // Get a list of the output filter ItemType's NamespacedKeys as a String to save.
+            List<String> containerFilterItemNames = skyContainer.getFilterItems().stream().map(itemType -> itemType.getKey().toString()).toList();
+            // Save the output filter items
             persistentDataContainer.set(HopperKeys.FILTER_ITEMS.getKey(),
-                    PersistentDataType.LIST.listTypeFrom(PersistentDataType.STRING),
-                    Objects.requireNonNull(skyContainer.getFilterItems()).stream().map(ItemType::toString).filter(Objects::nonNull)
-                            .collect(Collectors.toList()));
+                    PersistentDataType.LIST.listTypeFrom(PersistentDataType.STRING), containerFilterItemNames);
 
             pdcList.add(persistentDataContainer);
         }
@@ -651,5 +659,4 @@ public class HopperManager {
             });
         });
     }
-
 }


### PR DESCRIPTION
* Fix an issue where items could be removed from the GUIs for 1 tick due to removing the GUI as open for the player before the GUI was actually closed.
* Add 1.21.10 as a supported version to README.md and update the paper api dependency to use 1.21.10.
* Fix the output filter GUI not allowing players to input items to filter.
* Cleanup the InputFilterGUI#handleBottomClick method.
* Fix the filtered items for the input and container filters being improperly saved and loaded.